### PR TITLE
Update Comscore to 6.10.2

### DIFF
--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
         "state": {
           "branch": null,
-          "revision": "7e3c521ad689b0e2bbf5cfb62e19c9e1619feae2",
-          "version": "6.10.0"
+          "revision": "ede1a4aee58fc63a308e2babf3e33f55fedecb68",
+          "version": "6.10.2"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
         "state": {
           "branch": null,
-          "revision": "7e3c521ad689b0e2bbf5cfb62e19c9e1619feae2",
-          "version": "6.10.0"
+          "revision": "ede1a4aee58fc63a308e2babf3e33f55fedecb68",
+          "version": "6.10.2"
         }
       },
       {


### PR DESCRIPTION
### Motivation and Context

Update Comscore dependency to latest version.

### Description

- Update Comscore to 6.10.2.

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
