### PR TITLE
Update SRGMediaPlayer and SRGDataProvider

### DIFF
--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,9 +68,9 @@
         "package": "SRGDataProvider",
         "repositoryURL": "https://github.com/SRGSSR/srgdataprovider-apple.git",
         "state": {
-          "branch": "develop",
-          "revision": "1300445e42638f00bc4a0281000e21a70c4bd3ee",
-          "version": null
+          "branch": null,
+          "revision": "93a46a26d9ea068e3d812755e5a44c7402b2ad04",
+          "version": "18.0.0"
         }
       },
       {

--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/SRGSSR/srgmediaplayer-apple.git",
         "state": {
           "branch": null,
-          "revision": "0e5993756dc0fdfa892205fcf5bf3b9e62dd22ac",
-          "version": "7.1.0"
+          "revision": "63a8b41213360f625f2171a18718a7e5f14c4874",
+          "version": "7.2.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,9 +68,9 @@
         "package": "SRGDataProvider",
         "repositoryURL": "https://github.com/SRGSSR/srgdataprovider-apple.git",
         "state": {
-          "branch": "develop",
-          "revision": "1300445e42638f00bc4a0281000e21a70c4bd3ee",
-          "version": null
+          "branch": null,
+          "revision": "93a46a26d9ea068e3d812755e5a44c7402b2ad04",
+          "version": "18.0.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/SRGSSR/srgmediaplayer-apple.git",
         "state": {
           "branch": null,
-          "revision": "0e5993756dc0fdfa892205fcf5bf3b9e62dd22ac",
-          "version": "7.1.0"
+          "revision": "63a8b41213360f625f2171a18718a7e5f14c4874",
+          "version": "7.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         .package(name: "SRGDataProvider", url: "https://github.com/SRGSSR/srgdataprovider-apple.git", .branch("develop")),
         .package(name: "SRGIdentity", url: "https://github.com/SRGSSR/srgidentity-apple.git", .upToNextMinor(from: "3.3.0")),
         .package(name: "SRGLogger", url: "https://github.com/SRGSSR/srglogger-apple.git", .upToNextMinor(from: "3.1.0")),
-        .package(name: "SRGMediaPlayer", url: "https://github.com/SRGSSR/srgmediaplayer-apple.git", .upToNextMinor(from: "7.1.0")),
+        .package(name: "SRGMediaPlayer", url: "https://github.com/SRGSSR/srgmediaplayer-apple.git", .upToNextMinor(from: "7.2.0")),
         .package(name: "TCCore", url: "https://github.com/SRGSSR/TCCore-xcframework-apple.git", .exact("4.5.4-srg5")),
         .package(name: "TCSDK", url: "https://github.com/SRGSSR/TCSDK-xcframework-apple.git", .exact("4.4.1-srg5"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
     dependencies: [
         .package(name: "ComScore", url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.10.0")),
         .package(name: "SRGContentProtection", url: "https://github.com/SRGSSR/srgcontentprotection-apple.git", .upToNextMinor(from: "3.1.0")),
-        .package(name: "SRGDataProvider", url: "https://github.com/SRGSSR/srgdataprovider-apple.git", .branch("develop")),
+        .package(name: "SRGDataProvider", url: "https://github.com/SRGSSR/srgdataprovider-apple.git", .upToNextMinor(from: "18.0.0")),
         .package(name: "SRGIdentity", url: "https://github.com/SRGSSR/srgidentity-apple.git", .upToNextMinor(from: "3.3.0")),
         .package(name: "SRGLogger", url: "https://github.com/SRGSSR/srglogger-apple.git", .upToNextMinor(from: "3.1.0")),
         .package(name: "SRGMediaPlayer", url: "https://github.com/SRGSSR/srgmediaplayer-apple.git", .upToNextMinor(from: "7.2.0")),

--- a/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,9 +77,9 @@
         "package": "SRGDataProvider",
         "repositoryURL": "https://github.com/SRGSSR/srgdataprovider-apple.git",
         "state": {
-          "branch": "develop",
-          "revision": "1300445e42638f00bc4a0281000e21a70c4bd3ee",
-          "version": null
+          "branch": null,
+          "revision": "93a46a26d9ea068e3d812755e5a44c7402b2ad04",
+          "version": "18.0.0"
         }
       },
       {

--- a/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/SRGSSR/srgmediaplayer-apple.git",
         "state": {
           "branch": null,
-          "revision": "0e5993756dc0fdfa892205fcf5bf3b9e62dd22ac",
-          "version": "7.1.0"
+          "revision": "63a8b41213360f625f2171a18718a7e5f14c4874",
+          "version": "7.2.0"
         }
       },
       {


### PR DESCRIPTION
### Motivation and Context

Update SRG libraries.

### Description

- Update SRGMediaPlayer to 7.2.0 version: https://github.com/SRGSSR/srgmediaplayer-apple/releases/tag/7.2.0
- Update SRGDataProvider to 18.0.0 version: https://github.com/SRGSSR/srgdataprovider-apple/releases/tag/18.0.0

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.