### PR TITLE
Update SRG Media Player to 7.2.1

### DIFF
--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/SRGSSR/srgmediaplayer-apple.git",
         "state": {
           "branch": null,
-          "revision": "63a8b41213360f625f2171a18718a7e5f14c4874",
-          "version": "7.2.0"
+          "revision": "717608146d3787bd269d5a524e109ee30be828e4",
+          "version": "7.2.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/SRGSSR/srgmediaplayer-apple.git",
         "state": {
           "branch": null,
-          "revision": "63a8b41213360f625f2171a18718a7e5f14c4874",
-          "version": "7.2.0"
+          "revision": "717608146d3787bd269d5a524e109ee30be828e4",
+          "version": "7.2.1"
         }
       },
       {

--- a/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/SRGSSR/srgmediaplayer-apple.git",
         "state": {
           "branch": null,
-          "revision": "63a8b41213360f625f2171a18718a7e5f14c4874",
-          "version": "7.2.0"
+          "revision": "717608146d3787bd269d5a524e109ee30be828e4",
+          "version": "7.2.1"
         }
       },
       {


### PR DESCRIPTION
### Motivation and Context

Update SRG libraries to latest versions and remove warning to due an issue with SRGMediaPlayer 7.2.0 

### Description

- Update `SRGMediaPlayer` to 7.2.1

### Checklist

- [x] The branch should be rebased onto the `develop` branch for whole tests with nighties.
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
