### PR TITLE
Update analytics SDKs

### DIFF
--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "a25aa8b80a7fc4d455d8f75d81853d64e0c3ebaf",
-          "version": "5.4.0"
+          "revision": "921c98e57e3044377ee955db5282406e11e6a787",
+          "version": "5.4.1"
         }
       },
       {

--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
         "state": {
           "branch": null,
-          "revision": "ede1a4aee58fc63a308e2babf3e33f55fedecb68",
-          "version": "6.10.2"
+          "revision": "fef761279a592960243e67f2aea110c6fa097fd8",
+          "version": "6.11.0"
         }
       },
       {

--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "2e56e97db76d55657d0dc7d13e2fcd81ce4eaa6c",
-          "version": "5.3.3"
+          "revision": "a25aa8b80a7fc4d455d8f75d81853d64e0c3ebaf",
+          "version": "5.4.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
         "state": {
           "branch": null,
-          "revision": "ede1a4aee58fc63a308e2babf3e33f55fedecb68",
-          "version": "6.10.2"
+          "revision": "fef761279a592960243e67f2aea110c6fa097fd8",
+          "version": "6.11.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "2e56e97db76d55657d0dc7d13e2fcd81ce4eaa6c",
-          "version": "5.3.3"
+          "revision": "921c98e57e3044377ee955db5282406e11e6a787",
+          "version": "5.4.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         .package(name: "SRGIdentity", url: "https://github.com/SRGSSR/srgidentity-apple.git", .upToNextMinor(from: "3.3.0")),
         .package(name: "SRGLogger", url: "https://github.com/SRGSSR/srglogger-apple.git", .upToNextMinor(from: "3.1.0")),
         .package(name: "SRGMediaPlayer", url: "https://github.com/SRGSSR/srgmediaplayer-apple.git", .upToNextMinor(from: "7.2.0")),
-        .package(name: "TagCommander", url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.3.1"))
+        .package(name: "TagCommander", url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.0"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "ComScore", url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.10.0")),
+        .package(name: "ComScore", url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.11.0")),
         .package(name: "SRGContentProtection", url: "https://github.com/SRGSSR/srgcontentprotection-apple.git", .upToNextMinor(from: "3.1.0")),
         .package(name: "SRGDataProvider", url: "https://github.com/SRGSSR/srgdataprovider-apple.git", .upToNextMinor(from: "18.0.0")),
         .package(name: "SRGIdentity", url: "https://github.com/SRGSSR/srgidentity-apple.git", .upToNextMinor(from: "3.3.0")),


### PR DESCRIPTION
# Pull request

## Description

This PR allows us to update `comScore` and `TagCommander` SDKs.

## Changes made

- The `comScore` SDK has been updated to version **6.11.0**.
- The `TagCommander` SDK has been updated to version **5.4.1**.

