### PR TITLE
Add support to desktop navigation device

### DIFF
--- a/Sources/SRGAnalytics/SRGAnalyticsTracker.m
+++ b/Sources/SRGAnalytics/SRGAnalyticsTracker.m
@@ -197,7 +197,13 @@ void SRGAnalyticsRenewUnitTestingIdentifier(void)
 
 - (NSString *)device
 {
-    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+    if ([self isMacCatalystApp]) {
+        return @"desktop";
+    }
+    else if ([self isiOSAppOnMac]) {
+        return @"desktop";
+    }
+    else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
         return @"phone";
     }
     else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
@@ -208,6 +214,26 @@ void SRGAnalyticsRenewUnitTestingIdentifier(void)
     }
     else {
         return @"phone";
+    }
+}
+
+- (BOOL)isMacCatalystApp
+{
+    if (@available(iOS 13, tvOS 13, *)) {
+        return NSProcessInfo.processInfo.isMacCatalystApp;
+    }
+    else {
+        return NO;
+    }
+}
+
+- (BOOL)isiOSAppOnMac
+{
+    if (@available(iOS 14, tvOS 14, *)) {
+        return NSProcessInfo.processInfo.isiOSAppOnMac;
+    }
+    else {
+        return NO;
     }
 }
 

--- a/Sources/SRGAnalytics/SRGAnalyticsTracker.m
+++ b/Sources/SRGAnalytics/SRGAnalyticsTracker.m
@@ -172,7 +172,7 @@ void SRGAnalyticsRenewUnitTestingIdentifier(void)
     return labels.copy;
 }
 
-- (SRGAnalyticsLabels *)dataSourceLabels 
+- (SRGAnalyticsLabels *)dataSourceLabels
 {
     return self.dataSource.srg_globalLabels;
 }

--- a/Sources/SRGAnalytics/SRGAnalyticsTracker.m
+++ b/Sources/SRGAnalytics/SRGAnalyticsTracker.m
@@ -197,10 +197,7 @@ void SRGAnalyticsRenewUnitTestingIdentifier(void)
 
 - (NSString *)device
 {
-    if ([self isMacCatalystApp]) {
-        return @"desktop";
-    }
-    else if ([self isiOSAppOnMac]) {
+    if ([self isMacCatalystApp] || [self isiOSAppOnMac]) {
         return @"desktop";
     }
     else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {

--- a/Tests/SRGAnalyticsTests/MediaPlayerTestCase.m
+++ b/Tests/SRGAnalyticsTests/MediaPlayerTestCase.m
@@ -550,12 +550,7 @@ static NSURL *DVRTestURL(void)
     [self expectationForPlayerEventNotificationWithHandler:^BOOL(NSString *event, NSDictionary *labels) {
         XCTAssertEqualObjects(labels[@"app_library_version"], SRGAnalyticsMarketingVersion());
         XCTAssertEqualObjects(labels[@"navigation_app_site_name"], @"srg-test-analytics-apple");
-        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
-            XCTAssertEqualObjects(labels[@"navigation_device"], @"phone");
-        }
-        else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomTV) {
-            XCTAssertEqualObjects(labels[@"navigation_device"], @"tvbox");
-        }
+        XCTAssertTrue(([@[@"phone", @"tvbox", @"tablet", @"desktop"] containsObject:labels[@"navigation_device"]]));
         XCTAssertEqualObjects(labels[@"consent_services"], @"service1,service2,service3");
         
         XCTAssertEqualObjects(event, @"play");

--- a/Tests/SRGAnalyticsTests/MediaPlayerTestCase.m
+++ b/Tests/SRGAnalyticsTests/MediaPlayerTestCase.m
@@ -548,12 +548,20 @@ static NSURL *DVRTestURL(void)
 - (void)testCommonLabels
 {
     [self expectationForPlayerEventNotificationWithHandler:^BOOL(NSString *event, NSDictionary *labels) {
+        XCTAssertEqualObjects(labels[@"app_library_version"], SRGAnalyticsMarketingVersion());
         XCTAssertEqualObjects(labels[@"navigation_app_site_name"], @"srg-test-analytics-apple");
+        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+            XCTAssertEqualObjects(labels[@"navigation_device"], @"phone");
+        }
+        else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomTV) {
+            XCTAssertEqualObjects(labels[@"navigation_device"], @"tvbox");
+        }
+        XCTAssertEqualObjects(labels[@"consent_services"], @"service1,service2,service3");
+        
         XCTAssertEqualObjects(event, @"play");
         XCTAssertEqualObjects(labels[@"media_player_display"], @"SRGMediaPlayer");
         XCTAssertEqualObjects(labels[@"media_player_version"], SRGMediaPlayerMarketingVersion());
         XCTAssertEqualObjects(labels[@"test_label"], @"test_value");
-        XCTAssertEqualObjects(labels[@"consent_services"], @"service1,service2,service3");
         return YES;
     }];
     

--- a/Tests/SRGAnalyticsTests/TrackerTestCase.m
+++ b/Tests/SRGAnalyticsTests/TrackerTestCase.m
@@ -36,7 +36,14 @@
 - (void)testCommonLabelsForEvent
 {
     [self expectationForEventNotificationWithHandler:^BOOL(NSString *event, NSDictionary *labels) {
+        XCTAssertEqualObjects(labels[@"app_library_version"], SRGAnalyticsMarketingVersion());
         XCTAssertEqualObjects(labels[@"navigation_app_site_name"], @"srg-test-analytics-apple");
+        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+            XCTAssertEqualObjects(labels[@"navigation_device"], @"phone");
+        }
+        else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomTV) {
+            XCTAssertEqualObjects(labels[@"navigation_device"], @"tvbox");
+        }
         XCTAssertEqualObjects(labels[@"consent_services"], @"service1,service2,service3");
         return YES;
     }];
@@ -49,7 +56,15 @@
 - (void)testCommonLabelsForPageView
 {
     [self expectationForPageViewEventNotificationWithHandler:^BOOL(NSString *event, NSDictionary *labels) {
+        XCTAssertEqualObjects(labels[@"app_library_version"], SRGAnalyticsMarketingVersion());
         XCTAssertEqualObjects(labels[@"navigation_app_site_name"], @"srg-test-analytics-apple");
+        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+            XCTAssertEqualObjects(labels[@"navigation_device"], @"phone");
+        }
+        else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomTV) {
+            XCTAssertEqualObjects(labels[@"navigation_device"], @"tvbox");
+        }
+        XCTAssertEqualObjects(labels[@"consent_services"], @"service1,service2,service3");
         return YES;
     }];
     

--- a/Tests/SRGAnalyticsTests/TrackerTestCase.m
+++ b/Tests/SRGAnalyticsTests/TrackerTestCase.m
@@ -38,12 +38,7 @@
     [self expectationForEventNotificationWithHandler:^BOOL(NSString *event, NSDictionary *labels) {
         XCTAssertEqualObjects(labels[@"app_library_version"], SRGAnalyticsMarketingVersion());
         XCTAssertEqualObjects(labels[@"navigation_app_site_name"], @"srg-test-analytics-apple");
-        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
-            XCTAssertEqualObjects(labels[@"navigation_device"], @"phone");
-        }
-        else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomTV) {
-            XCTAssertEqualObjects(labels[@"navigation_device"], @"tvbox");
-        }
+        XCTAssertTrue(([@[@"phone", @"tvbox", @"tablet", @"desktop"] containsObject:labels[@"navigation_device"]]));
         XCTAssertEqualObjects(labels[@"consent_services"], @"service1,service2,service3");
         return YES;
     }];
@@ -58,12 +53,7 @@
     [self expectationForPageViewEventNotificationWithHandler:^BOOL(NSString *event, NSDictionary *labels) {
         XCTAssertEqualObjects(labels[@"app_library_version"], SRGAnalyticsMarketingVersion());
         XCTAssertEqualObjects(labels[@"navigation_app_site_name"], @"srg-test-analytics-apple");
-        if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
-            XCTAssertEqualObjects(labels[@"navigation_device"], @"phone");
-        }
-        else if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomTV) {
-            XCTAssertEqualObjects(labels[@"navigation_device"], @"tvbox");
-        }
+        XCTAssertTrue(([@[@"phone", @"tvbox", @"tablet", @"desktop"] containsObject:labels[@"navigation_device"]]));
         XCTAssertEqualObjects(labels[@"consent_services"], @"service1,service2,service3");
         return YES;
     }];

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,7 +27,7 @@ platform :ios do
     clean_derived_data
 
     iphone14 = Device.new('iOS', 'iPhone 14')
-    appletv = Device.new('tvOS', 'Apple TV')
+    appletv = Device.new('tvOS', 'Apple TV, OS=17.0')
     devices = [iphone14, appletv]
 
     scheme = swift_package_name

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,7 +27,7 @@ platform :ios do
     clean_derived_data
 
     iphone14 = Device.new('iOS', 'iPhone 14')
-    appletv = Device.new('tvOS', 'Apple TV, OS=17.0')
+    appletv = Device.new('tvOS', 'Apple TV,OS=17.0')
     devices = [iphone14, appletv]
 
     scheme = swift_package_name


### PR DESCRIPTION
# Description

This PR adds `desktop` support for `navigation_device`, according to [SRGAnalytics-documentation](https://github.com/SRGSSR/srganalytics-documentation) (on all events: [pageView](https://github.com/SRGSSR/srganalytics-documentation/blob/346bbc663c4d5b729ec37ff9ab5511b396ee2d35/schemas/com.srgssr/page_view/jsonschema/1-0-0.json#L161C20-L161C20), [media events](https://github.com/SRGSSR/srganalytics-documentation/blob/346bbc663c4d5b729ec37ff9ab5511b396ee2d35/schemas/com.srgssr/media_event/jsonschema/1-0-0.json#L448) and events).

Inspired by https://github.com/SRGSSR/pillarbox-apple/pull/364.

# Changes made

- Use `isMacCatalystApp` and `isiOSAppOnMac` on `NSProcessInfo` to set `desktop` value for `navigation_device` property.
- Add missing common properties in tests.