### PR TITLE
Use common Commanders Act unique identifier between v4 and v5

### DIFF
--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "921c98e57e3044377ee955db5282406e11e6a787",
-          "version": "5.4.1"
+          "revision": "1350bca4163cfdd62d1508068601817d86d9f4a5",
+          "version": "5.4.4"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "921c98e57e3044377ee955db5282406e11e6a787",
-          "version": "5.4.1"
+          "revision": "1350bca4163cfdd62d1508068601817d86d9f4a5",
+          "version": "5.4.4"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         .package(name: "SRGIdentity", url: "https://github.com/SRGSSR/srgidentity-apple.git", .upToNextMinor(from: "3.3.0")),
         .package(name: "SRGLogger", url: "https://github.com/SRGSSR/srglogger-apple.git", .upToNextMinor(from: "3.1.0")),
         .package(name: "SRGMediaPlayer", url: "https://github.com/SRGSSR/srgmediaplayer-apple.git", .upToNextMinor(from: "7.2.0")),
-        .package(name: "TagCommander", url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.0"))
+        .package(name: "TagCommander", url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.4"))
     ],
     targets: [
         .target(

--- a/Sources/SRGAnalytics/SRGAnalyticsTracker.m
+++ b/Sources/SRGAnalytics/SRGAnalyticsTracker.m
@@ -126,6 +126,10 @@ void SRGAnalyticsRenewUnitTestingIdentifier(void)
     [self.serverSide addPermanentData:@"app_library_version" withValue:SRGAnalyticsMarketingVersion()];
     [self.serverSide addPermanentData:@"navigation_app_site_name" withValue:configuration.siteName];
     [self.serverSide addPermanentData:@"navigation_device" withValue:[self device]];
+
+    // Use the legacy V4 identifier as unique identifier in V5.
+    TCDevice.sharedInstance.sdkID = TCPredefinedVariables.sharedInstance.uniqueIdentifier;
+    [TCPredefinedVariables.sharedInstance useLegacyUniqueIDForAnonymousID];
 }
 
 #pragma mark Labels

--- a/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "921c98e57e3044377ee955db5282406e11e6a787",
-          "version": "5.4.1"
+          "revision": "1350bca4163cfdd62d1508068601817d86d9f4a5",
+          "version": "5.4.4"
         }
       },
       {

--- a/Tests/SRGAnalyticsTests/TrackerTestCase.m
+++ b/Tests/SRGAnalyticsTests/TrackerTestCase.m
@@ -8,6 +8,8 @@
 #import "TrackerSingletonSetup.h"
 #import "XCTestCase+Tests.h"
 
+@import TCServerSide_noIDFA;
+
 @interface TrackerTestCase : XCTestCase
 
 @end
@@ -31,6 +33,20 @@
 - (void)testNoHiddenAdSupportFramework
 {
     XCTAssertNil(NSClassFromString(@"ASIdentifierManager"));
+}
+
+- (void)testUniqueIdentifier
+{
+    NSString *uniqueIdentifier = TCPredefinedVariables.sharedInstance.uniqueIdentifier;
+    [self expectationForEventNotificationWithHandler:^BOOL(NSString *event, NSDictionary *labels) {
+        XCTAssertEqualObjects(labels[@"context"][@"device"][@"sdk_id"], uniqueIdentifier);
+        XCTAssertEqualObjects(labels[@"user"][@"consistent_anonymous_id"], uniqueIdentifier);
+        return YES;
+    }];
+
+    [SRGAnalyticsTracker.sharedTracker trackEventWithName:@"Event"];
+
+    [self waitForExpectationsWithTimeout:20. handler:nil];
 }
 
 - (void)testCommonLabelsForEvent


### PR DESCRIPTION
# Description

This PR uses the same unique identifier between v4 and v5, ensuring users are identified correctly between app updates to v5.

# Changes made

- Override SDK identifier.
- Update to Commanders Act SDK 5.4.4 so that required APIs are available.
