### PR TITLE
Add compilation warning about SRG Analytics decommissioning

### DIFF
--- a/Sources/SRGAnalytics/SRGAnalytics.m
+++ b/Sources/SRGAnalytics/SRGAnalytics.m
@@ -6,6 +6,8 @@
 
 #import "SRGAnalytics.h"
 
+#warning "SRG Analytics will be sunset in August 2025. Please upgrade to Pillarbox Analytics (https://github.com/SRGSSR/pillarbox-apple)."
+
 NSString *SRGAnalyticsMarketingVersion(void)
 {
     return @MARKETING_VERSION;


### PR DESCRIPTION
# Description

This PR adds a decommissioning warning when compiling SRG Analytics. We start to annoy users a little bit so that they migrate to Pillarbox.

# Changes made

Self-explanatory.