### PR TITLE
Wait until the User Agent is retrieved by Commanders Act

### DIFF
--- a/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SRGAnalytics-demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
         "state": {
           "branch": null,
-          "revision": "fef761279a592960243e67f2aea110c6fa097fd8",
-          "version": "6.11.0"
+          "revision": "2d1cd9c0cb52ca76702023b528a059fc0a7d5a4d",
+          "version": "6.13.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "1350bca4163cfdd62d1508068601817d86d9f4a5",
-          "version": "5.4.4"
+          "revision": "b65eb27cde41d3c40b05520f8713d55a52821553",
+          "version": "5.4.9"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -36,13 +36,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "ComScore", url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.11.0")),
+        .package(name: "ComScore", url: "https://github.com/comScore/Comscore-Swift-Package-Manager.git", .upToNextMinor(from: "6.13.0")),
         .package(name: "SRGContentProtection", url: "https://github.com/SRGSSR/srgcontentprotection-apple.git", .upToNextMinor(from: "3.1.0")),
         .package(name: "SRGDataProvider", url: "https://github.com/SRGSSR/srgdataprovider-apple.git", .upToNextMinor(from: "19.0.0")),
         .package(name: "SRGIdentity", url: "https://github.com/SRGSSR/srgidentity-apple.git", .upToNextMinor(from: "3.3.0")),
         .package(name: "SRGLogger", url: "https://github.com/SRGSSR/srglogger-apple.git", .upToNextMinor(from: "3.1.0")),
         .package(name: "SRGMediaPlayer", url: "https://github.com/SRGSSR/srgmediaplayer-apple.git", .upToNextMinor(from: "7.2.0")),
-        .package(name: "TagCommander", url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.4"))
+        .package(name: "TagCommander", url: "https://github.com/CommandersAct/iOSV5.git", .upToNextMinor(from: "5.4.9"))
     ],
     targets: [
         .target(

--- a/Sources/SRGAnalytics/SRGAnalyticsTracker.m
+++ b/Sources/SRGAnalytics/SRGAnalyticsTracker.m
@@ -122,6 +122,7 @@ void SRGAnalyticsRenewUnitTestingIdentifier(void)
 {
     self.serverSide = [[ServerSide alloc] initWithSiteID:(int)configuration.site andSourceKey:configuration.sourceKey];
     [self.serverSide enableRunningInBackground];
+    [self.serverSide waitForUserAgent];
 
     [self.serverSide addPermanentData:@"app_library_version" withValue:SRGAnalyticsMarketingVersion()];
     [self.serverSide addPermanentData:@"navigation_app_site_name" withValue:configuration.siteName];

--- a/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/SRGAnalyticsIdentity-tests.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/comScore/Comscore-Swift-Package-Manager.git",
         "state": {
           "branch": null,
-          "revision": "fef761279a592960243e67f2aea110c6fa097fd8",
-          "version": "6.11.0"
+          "revision": "2d1cd9c0cb52ca76702023b528a059fc0a7d5a4d",
+          "version": "6.13.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/CommandersAct/iOSV5.git",
         "state": {
           "branch": null,
-          "revision": "1350bca4163cfdd62d1508068601817d86d9f4a5",
-          "version": "5.4.4"
+          "revision": "b65eb27cde41d3c40b05520f8713d55a52821553",
+          "version": "5.4.9"
         }
       },
       {


### PR DESCRIPTION
# Description

This PR enables a Commanders Act opt-in that ensures User Agent retrieval before sending events. This should avoid inconsistent User Agents from being forwarded to Mapp.

# Changes made

Self-explanatory.
