### PR TITLE
Remove schemes declared in demo Info.plist

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -33,34 +33,6 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>srgtraffic</string>
-		<string>srf</string>
-		<string>srfsport</string>
-		<string>srfplayer</string>
-		<string>srfmeteo</string>
-		<string>srfradio3</string>
-		<string>srfvirus</string>
-		<string>srfjass</string>
-		<string>rtsinfo</string>
-		<string>rtssport</string>
-		<string>playrts</string>
-		<string>couleur3</string>
-		<string>dtqc3</string>
-		<string>rtsradio</string>
-		<string>rsinews</string>
-		<string>rsisport</string>
-		<string>playrsi</string>
-		<string>rsich</string>
-		<string>rsiibazaar</string>
-		<string>rsizerovero</string>
-		<string>rsipeo</string>
-		<string>playrtr</string>
-		<string>ch.swissinfo.news</string>
-		<string>playswi</string>
-		<string>tvsvizzera</string>
-	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## Description

This PR removes schemes declared in the demo Info.plist, not needed since #97 has been merged.

## Changes made

Self-explanatory.