### PR TITLE
Remove comScore page view tracking

### DIFF
--- a/Sources/SRGAnalytics/SRGAnalyticsTracker.m
+++ b/Sources/SRGAnalytics/SRGAnalyticsTracker.m
@@ -332,57 +332,6 @@ void SRGAnalyticsRenewUnitTestingIdentifier(void)
     }
     
     [self trackCommandersActPageViewWithTitle:title type:type levels:levels labels:labels fromPushNotification:fromPushNotification];
-    [self trackComScorePageViewWithTitle:title levels:levels labels:labels fromPushNotification:fromPushNotification];
-}
-
-- (void)trackComScorePageViewWithTitle:(NSString *)title
-                                levels:(NSArray<NSString *> *)levels
-                                labels:(SRGAnalyticsPageViewLabels *)labels
-                  fromPushNotification:(BOOL)fromPushNotification
-{
-    NSAssert(title.length != 0, @"A title is required");
-    
-    NSMutableDictionary<NSString *, NSString *> *fullLabels = self.defaultComScoreLabels.mutableCopy;
-    [fullLabels srg_safelySetString:title forKey:@"srg_title"];
-    [fullLabels srg_safelySetString:@(fromPushNotification).stringValue forKey:@"srg_ap_push"];
-    
-    NSString *category = @"app";
-    
-    if (! levels) {
-        [fullLabels srg_safelySetString:category forKey:@"srg_n1"];
-    }
-    else if (levels.count > 0) {
-        __block NSMutableString *levelsComScoreFormattedString = [NSMutableString new];
-        [levels enumerateObjectsUsingBlock:^(NSString * _Nonnull object, NSUInteger idx, BOOL * _Nonnull stop) {
-            NSString *levelKey = [NSString stringWithFormat:@"srg_n%@", @(idx + 1)];
-            NSString *levelValue = [object description];
-            
-            if (idx < 10) {
-                [fullLabels srg_safelySetString:levelValue forKey:levelKey];
-            }
-            
-            if (levelsComScoreFormattedString.length > 0) {
-                [levelsComScoreFormattedString appendString:@"."];
-            }
-            [levelsComScoreFormattedString appendString:levelValue.srg_comScoreFormattedString];
-        }];
-        
-        category = levelsComScoreFormattedString.copy;
-    }
-    
-    [fullLabels srg_safelySetString:category forKey:@"ns_category"];
-    [fullLabels srg_safelySetString:[self pageIdWithTitle:title levels:levels] forKey:@"name"];
-    
-    NSDictionary<NSString *, NSString *> *comScoreLabelsDictionary = [labels comScoreLabelsDictionary];
-    if (comScoreLabelsDictionary) {
-        [fullLabels addEntriesFromDictionary:comScoreLabelsDictionary];
-    }
-    
-    if (self.configuration.unitTesting) {
-        [fullLabels srg_safelySetString:SRGAnalyticsUnitTestingIdentifier() forKey:@"srg_test_id"];
-    }
-    
-    [SCORAnalytics notifyViewEventWithLabels:fullLabels.copy];
 }
 
 - (void)trackCommandersActPageViewWithTitle:(NSString *)title

--- a/Sources/SRGAnalytics/include/SRGAnalyticsTracker.h
+++ b/Sources/SRGAnalytics/include/SRGAnalyticsTracker.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  The SRG Analytics library supports three kinds of measurements:
  *    - View events: Appearance of views (page views), which makes it possible to track which content is seen by users.
- *    - Events: Custom events which can be used for measuresement of application functionalities.
+ *    - Events: Custom events which can be used for measurement of application functionalities.
  *    - Stream playback events: Measurements for audio and video consumption.
  *
  *  For all kinds of measurements, required information must be provided through mandatory parameters, and optional
@@ -172,7 +172,7 @@ NS_EXTENSION_UNAVAILABLE("SRG Analytics does not support application extensions"
  *  This is for example the case if your application runs a secondary external window while it might itself be in the
  *  background (e.g. CarPlay scene).
  *
- *  Be extremely careful when using the APIs below, as your application might be rejected if illegitmate page views are
+ *  Be extremely careful when using the APIs below, as your application might be rejected if illegitimate page views are
  *  emitted in the background.
  */
 @interface SRGAnalyticsTracker (UncheckedPageViewTracking)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -140,7 +140,6 @@ and implement the methods you need to supply measurement information:
     SRGAnalyticsPageViewLabels *labels = [[SRGAnalyticsPageViewLabels alloc] init];
     labels.customInfo = @{ @"MYAPP_CATEGORY" : @"general",
                            @"MYAPP_TIME" : @"1499319314" };
-    labels.comScoreCustomInfo = @{ @"myapp_category" : @"gen" };
     return labels;
 }
 
@@ -149,7 +148,7 @@ and implement the methods you need to supply measurement information:
 
 When the view is opened for the first time, or if the view is visible on screen when waking up the application, this information will be automatically sent.
 
-Note that the labels might differ depending on the service they are sent to. Be sure to apply the conventions required for measurements of your application. Moreover, custom information requires the corresponding variables to be defined for Commanders Act first (unlike comScore information which can be freely defined).
+Note that the labels might differ depending on the service they are sent to. Be sure to apply the conventions required for measurements of your application. Moreover, custom information requires the corresponding variables to be defined server-side for Commanders Act first.
 
 ## Measuring page views (SwiftUI)
 
@@ -160,7 +159,8 @@ struct ContentView: View {
     var body: some View {
         VStack {
             // ...
-        }.tracked(withTitle: "home", type: "landing_page")
+        }
+        .tracked(withTitle: "home", type: "landing_page")
     }
 }
 ```


### PR DESCRIPTION
## Description

This PR removes comScore page view tracking. This is only the first phase of the removal, [another update](https://github.com/SRGSSR/srganalytics-apple/issues/101) will be performed at a later time.

Note that only minimal changes have been made. Most notably it is still possible to associate comScore custom data with page view event labels. This data will simply be ignored.

## Changes made

- Remove internal comScore page view tracking call.
- Update documentation.