### PR TITLE
Replace `navigation_bu_distributer` with `content_bu_owner`

### DIFF
--- a/Sources/SRGAnalytics/SRGAnalyticsTracker.m
+++ b/Sources/SRGAnalytics/SRGAnalyticsTracker.m
@@ -342,7 +342,7 @@ void SRGAnalyticsRenewUnitTestingIdentifier(void)
 {
     NSMutableDictionary<NSString *, NSString *> *fullLabels = [NSMutableDictionary dictionary];
     [fullLabels srg_safelySetString:@"app" forKey:@"navigation_property_type"];
-    [fullLabels srg_safelySetString:self.configuration.businessUnitIdentifier.uppercaseString forKey:@"navigation_bu_distributer"];
+    [fullLabels srg_safelySetString:self.configuration.businessUnitIdentifier.uppercaseString forKey:@"content_bu_owner"];
     [fullLabels srg_safelySetString:fromPushNotification ? @"true" : @"false" forKey:@"accessed_after_push_notification"];
 
     [levels enumerateObjectsUsingBlock:^(NSString * _Nonnull object, NSUInteger idx, BOOL * _Nonnull stop) {

--- a/Tests/SRGAnalyticsTests/TrackerTestCase.m
+++ b/Tests/SRGAnalyticsTests/TrackerTestCase.m
@@ -137,7 +137,7 @@
         XCTAssertNotNil(labels[@"accessed_after_push_notification"]);
         XCTAssertFalse([labels[@"accessed_after_push_notification"] boolValue]);
         XCTAssertEqualObjects(labels[@"navigation_property_type"], @"app");
-        XCTAssertEqualObjects(labels[@"navigation_bu_distributer"], @"SRG");
+        XCTAssertEqualObjects(labels[@"content_bu_owner"], @"SRG");
         return YES;
     }];
     


### PR DESCRIPTION
## Description

This PR renames field `navigation_bu_distributer` to `content_bu_owner` for **CommandersAct** page view tracking.

## Changes made

Self-explanatory.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
